### PR TITLE
Improve display of CustomDebugInformation records

### DIFF
--- a/src/Microsoft.Metadata.Visualizer/MetadataVisualizer.cs
+++ b/src/Microsoft.Metadata.Visualizer/MetadataVisualizer.cs
@@ -22,7 +22,8 @@ namespace Microsoft.Metadata.Tools
     {
         None = 0,
         ShortenBlobs = 1,
-        NoHeapReferences = 1 << 1
+        NoHeapReferences = 1 << 1,
+        EmbeddedSource = 1 << 2
     }
 
     public sealed partial class MetadataVisualizer
@@ -2113,9 +2114,9 @@ namespace Microsoft.Metadata.Tools
                 return VisualizeCompilationOptions(blobReader);
             }
 
-            if (kind == PortableCustomDebugInfoKinds.EmbeddedSource)
+            if (kind == PortableCustomDebugInfoKinds.EmbeddedSource && _options.HasFlag(MetadataVisualizerOptions.EmbeddedSource))
             {
-                 return VisualizeEmbeddedSource(blobReader);
+                return VisualizeEmbeddedSource(blobReader);
             }
 
             return null;
@@ -2241,7 +2242,7 @@ namespace Microsoft.Metadata.Tools
                     deflate.CopyTo(uncompressedStream);
                     bytes = uncompressedStream.ToArray();
                 }
-                catch 
+                catch
                 {
                     bytes = null;
                 };

--- a/src/Microsoft.Metadata.Visualizer/MetadataVisualizer.cs
+++ b/src/Microsoft.Metadata.Visualizer/MetadataVisualizer.cs
@@ -2230,13 +2230,11 @@ namespace Microsoft.Metadata.Tools
             try { format = reader.ReadInt32(); } catch { };
             byte[] bytes = null;
             try { bytes = reader.ReadBytes(reader.RemainingBytes); } catch { };
-                
-           
+
             if (format > 0 && bytes != null)
             {
                 try
                 {
-
                     using var compressedStream = new MemoryStream(bytes, writable: false);
                     using var uncompressedStream = new MemoryStream();
                     using var deflate = new DeflateStream(compressedStream, CompressionMode.Decompress);

--- a/src/Microsoft.Metadata.Visualizer/MetadataVisualizer.cs
+++ b/src/Microsoft.Metadata.Visualizer/MetadataVisualizer.cs
@@ -2055,7 +2055,7 @@ namespace Microsoft.Metadata.Tools
             {
                 var entry = _reader.GetCustomDebugInformation(handle);
 
-                table.AddRowWithDetails( 
+                table.AddRowWithDetails(
                     fields: new[]
                     {
                         Token(() => entry.Parent),
@@ -2112,7 +2112,8 @@ namespace Microsoft.Metadata.Tools
             {
                 return VisualizeCompilationOptions(blobReader);
             }
-            if(kind ==  PortableCustomDebugInfoKinds.EmbeddedSource)
+
+            if (kind == PortableCustomDebugInfoKinds.EmbeddedSource)
             {
                  return VisualizeEmbeddedSource(blobReader);
             }
@@ -2220,14 +2221,14 @@ namespace Microsoft.Metadata.Tools
             builder.AppendLine("}");
             return builder.ToString();
         }
+
         private static string VisualizeEmbeddedSource(BlobReader reader)
         {
-            var utf8 = new UTF8Encoding();
             var builder = new StringBuilder();
             builder.AppendLine(">>>");
             int format = -1;
             try { format = reader.ReadInt32(); } catch { };
-            byte[] bytes= null;
+            byte[] bytes = null;
             try { bytes = reader.ReadBytes(reader.RemainingBytes); } catch { };
                 
            
@@ -2246,16 +2247,16 @@ namespace Microsoft.Metadata.Tools
                 {
                     bytes = null;
                 };
-       
             }
+
             if (format < 0 || bytes == null)
             {
                 builder.AppendLine(BadMetadataStr);
             }
             else
             {
-                builder.AppendLine(utf8.GetString(bytes));
-                builder.AppendLine("### End of Embedded Source");
+                builder.AppendLine(Encoding.UTF8.GetString(bytes));
+                builder.AppendLine("<<< End of Embedded Source");
             }
             return builder.ToString();
         }

--- a/src/Microsoft.Metadata.Visualizer/MetadataVisualizer.cs
+++ b/src/Microsoft.Metadata.Visualizer/MetadataVisualizer.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
@@ -2054,7 +2055,7 @@ namespace Microsoft.Metadata.Tools
             {
                 var entry = _reader.GetCustomDebugInformation(handle);
 
-                table.AddRowWithDetails(
+                table.AddRowWithDetails( 
                     fields: new[]
                     {
                         Token(() => entry.Parent),
@@ -2111,12 +2112,16 @@ namespace Microsoft.Metadata.Tools
             {
                 return VisualizeCompilationOptions(blobReader);
             }
+            if(kind ==  PortableCustomDebugInfoKinds.EmbeddedSource)
+            {
+                 return VisualizeEmbeddedSource(blobReader);
+            }
 
             return null;
         }
 
         private static string VisualizeSourceLink(BlobReader reader)
-            => reader.ReadUTF8(reader.RemainingBytes);
+            => reader.ReadUTF8(reader.RemainingBytes) + Environment.NewLine;
 
         private static string TryReadUtf8NullTerminated(ref BlobReader reader)
         {
@@ -2213,6 +2218,45 @@ namespace Microsoft.Metadata.Tools
             }
 
             builder.AppendLine("}");
+            return builder.ToString();
+        }
+        private static string VisualizeEmbeddedSource(BlobReader reader)
+        {
+            var utf8 = new UTF8Encoding();
+            var builder = new StringBuilder();
+            builder.AppendLine(">>>");
+            int format = -1;
+            try { format = reader.ReadInt32(); } catch { };
+            byte[] bytes= null;
+            try { bytes = reader.ReadBytes(reader.RemainingBytes); } catch { };
+                
+           
+            if (format > 0 && bytes != null)
+            {
+                try
+                {
+
+                    using var compressedStream = new MemoryStream(bytes, writable: false);
+                    using var uncompressedStream = new MemoryStream();
+                    using var deflate = new DeflateStream(compressedStream, CompressionMode.Decompress);
+                    deflate.CopyTo(uncompressedStream);
+                    bytes = uncompressedStream.ToArray();
+                }
+                catch 
+                {
+                    bytes = null;
+                };
+       
+            }
+            if (format < 0 || bytes == null)
+            {
+                builder.AppendLine(BadMetadataStr);
+            }
+            else
+            {
+                builder.AppendLine(utf8.GetString(bytes));
+                builder.AppendLine("### End of Embedded Source");
+            }
             return builder.ToString();
         }
 

--- a/src/mdv/Arguments.cs
+++ b/src/mdv/Arguments.cs
@@ -17,6 +17,7 @@ internal sealed class Arguments
     public bool DisplayIL { get; private set; }
     public bool DisplayEmbeddedPdb { get; private set; }
     public bool DisplayMetadata { get; private set; }
+    public bool DisplayEmbeddedSource { get; private set; }
     public string OutputPath { get; private set; }
     public ImmutableArray<string> FindRefs { get; private set; }
 
@@ -30,7 +31,8 @@ Parameters:
 /assemblyRefs[+|-]                        Display/hide assembly references.
 /il[+|-]                                  Display/hide IL of method bodies.
 /md[+|-]                                  Display/hide metadata tables.
-/embeddedpdb[+|-]                         Display embedded PDB insted of the type system metadata.
+/embeddedSource[+|-]                      Display/hide embedded source.
+/embeddedPdb[+|-]                         Display embedded PDB insted of the type system metadata.
 /findRef:<MemberRefs>                     Displays all assemblies containing the specified MemberRefs: 
                                           a semicolon separated list of 
                                           <assembly display name>:<qualified-type-name>:<member-name>
@@ -77,10 +79,12 @@ If /g is specified the path must be baseline PE file (generation 0).
 
         result.DisplayIL = ParseFlagArg(args, "il", defaultValue: !result.Recursive && !findRefs);
         result.DisplayMetadata = ParseFlagArg(args, "md", defaultValue: !result.Recursive && !findRefs);
-        result.DisplayEmbeddedPdb = ParseFlagArg(args, "embeddedpdb", defaultValue: false);
+        result.DisplayEmbeddedPdb = ParseFlagArg(args, "embeddedPdb", defaultValue: false);
         result.DisplayStatistics = ParseFlagArg(args, "stats", defaultValue: result.Recursive && !findRefs);
         result.DisplayAssemblyReferences = ParseFlagArg(args, "stats", defaultValue: !findRefs);
+        result.DisplayEmbeddedSource = ParseFlagArg(args, "embeddedSource", defaultValue: false);
         result.OutputPath = ParseValueArg(args, "out");
+       
 
         if (result.DisplayEmbeddedPdb && result.EncDeltas.Count > 0)
         {
@@ -103,8 +107,9 @@ If /g is specified the path must be baseline PE file (generation 0).
         string offStr = "/" + name + "-";
 
         return args.Aggregate(defaultValue, (value, arg) =>
-            arg.Equals(onStr1, StringComparison.OrdinalIgnoreCase) || arg.Equals(onStr2, StringComparison.OrdinalIgnoreCase) ? true :
+            (arg.Equals(onStr1, StringComparison.OrdinalIgnoreCase) || arg.Equals(onStr2, StringComparison.OrdinalIgnoreCase)) ? true :
             arg.Equals(offStr, StringComparison.OrdinalIgnoreCase) ? false :
             value);
     }
 }
+

--- a/src/mdv/Mdv.cs
+++ b/src/mdv/Mdv.cs
@@ -231,7 +231,12 @@ namespace Microsoft.Metadata.Tools
         private void VisualizeGenerations(List<GenerationData> generations)
         {
             var mdReaders = generations.Select(g => g.MetadataReader).ToArray();
-            var visualizer = new MetadataVisualizer(mdReaders, _writer);
+
+            var options = _arguments.DisplayEmbeddedSource ?
+                MetadataVisualizerOptions.EmbeddedSource :
+                MetadataVisualizerOptions.None;
+
+            var visualizer = new MetadataVisualizer(mdReaders, _writer, options);
 
             for (int generationIndex = 0; generationIndex < generations.Count; generationIndex++)
             {

--- a/src/mdv/Mdv.cs
+++ b/src/mdv/Mdv.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Metadata.Tools
         public Mdv(Arguments arguments)
         {
             _arguments = arguments;
-            _writer = (arguments.OutputPath != null) ? new StreamWriter(File.OpenWrite(arguments.OutputPath), Encoding.UTF8) : Console.Out;
+            _writer = (arguments.OutputPath != null) ? new StreamWriter(File.Create(arguments.OutputPath), Encoding.UTF8) : Console.Out;
         }
 
         public void Dispose()


### PR DESCRIPTION
Changes made for formatting issue in CustomDebugInformation #2 compilation options was on the same line as #1. Also added data for Embedded sources, it now displays the source.

Fixes #97
Fixes #83