### PR TITLE
Upgrade to V4 Arcade publishing

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -12,8 +12,6 @@ pr:
 variables:
   - name: _TeamName
     value: Roslyn
-  - name: _PublishUsingPipelines
-    value: true
   - name: _DotNetArtifactsCategory
     value: .NETCore
 
@@ -27,7 +25,6 @@ stages:
       enablePublishBuildArtifacts: true
       enablePublishTestResults: true
       enablePublishBuildAssets: true
-      enablePublishUsingPipelines: $(_PublishUsingPipelines)
       enableTelemetry: true
       helixRepo: dotnet/symreader
       jobs:
@@ -51,7 +48,6 @@ stages:
                   /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
                   /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
                   /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
-                  /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
                   /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                   /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
         # else
@@ -135,7 +131,7 @@ stages:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
-      publishingInfraVersion: 3
+      publishingInfraVersion: 4
       # Symbol validation isn't being very reliable lately. This should be enabled back
       # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
       enableSymbolValidation: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,12 +58,13 @@ extends:
           enablePublishBuildArtifacts: true
           enablePublishTestResults: true
           enablePublishBuildAssets: true
-          enablePublishUsingPipelines: true
+          publishingVersion: 4
           enableTelemetry: true
           enableSourceBuild: true
           helixRepo: dotnet/metadata-tools
           jobs:
           - job: Windows
+            enablePublishing: true
             pool:
               ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
                 vmImage: 'windows-latest'
@@ -78,7 +79,6 @@ extends:
               - name: _OfficialBuildArgs
                 value: /p:DotNetSignType=$(_SignType) 
                        /p:TeamName=$(TeamName) 
-                       /p:DotNetPublishUsingPipelines=true 
                        /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
                  # else
             - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
@@ -147,5 +147,5 @@ extends:
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - template: /eng/common/templates-official/post-build/post-build.yml@self
         parameters:
-          publishingInfraVersion: 3
+          publishingInfraVersion: 4
           enableSymbolValidation: false

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
    <PropertyGroup>
-      <PublishingVersion>3</PublishingVersion>
+      <PublishingVersion>4</PublishingVersion>
    </PropertyGroup>
 </Project>


### PR DESCRIPTION
Upgrade to V4 Arcade publishing

This PR migrates dotnet/metadata-tools from Arcade V3 publishing to V4 publishing.

## Changes

| File | Change |
|------|--------|
| `eng/Publishing.props` | `PublishingVersion` 3 → 4 |
| `azure-pipelines.yml` | Removed `enablePublishUsingPipelines`, added `publishingVersion: 4` and `enablePublishing: true` on Windows job, removed `/p:DotNetPublishUsingPipelines=true` from build args, `publishingInfraVersion` 3 → 4 |
| `azure-pipelines-pr.yml` | Removed `_PublishUsingPipelines` variable, removed `enablePublishUsingPipelines`, removed `/p:DotNetPublishUsingPipelines` from build args, `publishingInfraVersion` 3 → 4 |

## Validation tracking
- Official validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2957932 (partiallySucceeded — Source-Build failed with pre-existing NU1510 error unrelated to V4 changes; Windows Release, Publish Assets, and Finalize all succeeded)
- Promotion build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2957983 (partiallySucceeded with only expected V3 fallback download warnings)
- Asset comparison: baseline BAR 307222 (build 20260322.1) vs new BAR 311487 (build 20260422.6) — 5 assets each, identities aligned (mdv, Microsoft.Metadata.Visualizer, symbol packages, manifest)
- MergedManifest.xml confirmed `PublishingVersion="4"`
- Tracker: https://github.com/dotnet/arcade/issues/16697