### PR TITLE
Conditionally add S.R.M as a package reference

### DIFF
--- a/src/Microsoft.Metadata.Visualizer/Microsoft.Metadata.Visualizer.csproj
+++ b/src/Microsoft.Metadata.Visualizer/Microsoft.Metadata.Visualizer.csproj
@@ -13,7 +13,7 @@
     <PackageTags>EMCA-335 metadata Portable PDB visualizer</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Reflection.Metadata" />
+    <PackageReference Include="System.Reflection.Metadata" Condition="'$(TargetFramework)' == 'net472'"/> />
     <PackageReference Include="Microsoft.CodeAnalysis.PooledObjects" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Debugging" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Microsoft.Metadata.Visualizer/Microsoft.Metadata.Visualizer.csproj
+++ b/src/Microsoft.Metadata.Visualizer/Microsoft.Metadata.Visualizer.csproj
@@ -13,7 +13,7 @@
     <PackageTags>EMCA-335 metadata Portable PDB visualizer</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Reflection.Metadata" Condition="'$(TargetFramework)' == 'net472'"/> />
+    <PackageReference Include="System.Reflection.Metadata" Condition="'$(TargetFramework)' == 'net472'" />
     <PackageReference Include="Microsoft.CodeAnalysis.PooledObjects" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Debugging" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
Official build is reporting 

> ##[error]src/Microsoft.Metadata.Visualizer/Microsoft.Metadata.Visualizer.csproj(0,0): error NU1510: (NETCORE_ENGINEERING_TELEMETRY=Build) PackageReference System.Reflection.Metadata will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.